### PR TITLE
Fixed a JS error due to the fact that the # needs to be escaped.

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -49,7 +49,7 @@ $(window).load(function() {
 
 $(function() {
 
-	$('a[href*=#]:not([href=#])').click(function() {
+	$('a[href*=\\#]:not([href=\\#])').click(function() {
 		if (location.pathname.replace(/^\//, '') === this.pathname.replace(/^\//, '') && location.hostname === this.hostname) {
 
 			var target = $(this.hash);


### PR DESCRIPTION
When loading the website, an error appears in the console: 

> Error: Syntax error, unrecognized expression: a[href*=#]:not([href=#])

This is due to the fact that the # character needs to be escaped. See [this thread](https://github.com/jquery/jquery/issues/2885).

This PR fixes this.