### PR TITLE
moved fontawesome include to https (as per issue #4)

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -25,7 +25,7 @@
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
         <![endif]-->
 
-        <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+        <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 
         {% block assets deferred %}
             {{ assets.css()|raw }}


### PR DESCRIPTION
As per issue #4, fontawesome is loaded over http causing it to fail when the page is loaded over https due to the mixed content policy of modern browsers.